### PR TITLE
removed scrollbar from editor panel

### DIFF
--- a/main.css
+++ b/main.css
@@ -41,3 +41,7 @@
 	position: absolute;
 	z-index: 50;
 }
+
+#editor-holder *::-webkit-scrollbar {
+    display: none;
+}


### PR DESCRIPTION
The scrollbar is unnecessary with the minimap. 
# editor-holder only contains the code mirror instance, so if someone can make the "#editor-holder *" more specific than we should, but I am not sure what that would be.
